### PR TITLE
Add api prefix oauth url

### DIFF
--- a/example.env
+++ b/example.env
@@ -11,6 +11,7 @@ PGADMIN_DEFAULT_PASSWORD=password
 
 FORTYTWO_APP_ID=
 FORTYTWO_APP_SECRET=
+OAUTH_LOGIN_URL=http://localhost:4211/api/auth/login
 OAUTH_REDIRECT_URL=http://localhost:4211/api/auth/callback
 FRONT_HOME_URL=http://localhost:4212/home
 

--- a/example.env
+++ b/example.env
@@ -11,10 +11,11 @@ PGADMIN_DEFAULT_PASSWORD=password
 
 FORTYTWO_APP_ID=
 FORTYTWO_APP_SECRET=
-OAUTH_LOGIN_URL=http://localhost:4211/api/auth/login
 OAUTH_REDIRECT_URL=http://localhost:4211/api/auth/callback
 FRONT_INDEX_URL=http://localhost:4212/
 
 HASH_SALT=10
 SESSION_SECRET=nestnestnest
 SESSION_COOKIE_MAX_AGE=604800000
+
+REACT_APP_OAUTH_LOGIN_URL=http://localhost:4211/api/auth/login

--- a/example.env
+++ b/example.env
@@ -12,7 +12,7 @@ PGADMIN_DEFAULT_PASSWORD=password
 FORTYTWO_APP_ID=
 FORTYTWO_APP_SECRET=
 OAUTH_REDIRECT_URL=http://localhost:4211/api/auth/callback
-FRONT_INDEX_URL=http://localhost:4212/
+FRONT_HOME_URL=http://localhost:4212/home
 
 HASH_SALT=10
 SESSION_SECRET=nestnestnest

--- a/example.env
+++ b/example.env
@@ -13,7 +13,7 @@ FORTYTWO_APP_ID=
 FORTYTWO_APP_SECRET=
 OAUTH_LOGIN_URL=http://localhost:4211/api/auth/login
 OAUTH_REDIRECT_URL=http://localhost:4211/api/auth/callback
-FRONT_HOME_URL=http://localhost:4212/home
+FRONT_INDEX_URL=http://localhost:4212/
 
 HASH_SALT=10
 SESSION_SECRET=nestnestnest

--- a/example.env
+++ b/example.env
@@ -11,7 +11,7 @@ PGADMIN_DEFAULT_PASSWORD=password
 
 FORTYTWO_APP_ID=
 FORTYTWO_APP_SECRET=
-OAUTH_REDIRECT_URL=http://localhost:4211/auth/callback
+OAUTH_REDIRECT_URL=http://localhost:4211/api/auth/callback
 FRONT_INDEX_URL=http://localhost:4212/
 
 HASH_SALT=10


### PR DESCRIPTION
## チケットへのリンク
[ユーザー認証機能の追加 #7](https://github.com/RIFT-tokyo/transcendence-front/issues/7)

## やったこと
 apiを追加
OAUTH_LOGIN_URL=http://localhost:4211/api/auth/login
OAUTH_REDIRECT_URL=http://localhost:4211/api/auth/callback

react用環境変数
REACT_APP_OAUTH_LOGIN_URL=http://localhost:4211/api/auth/login

## やらないこと

## テスト

## その他
