### PR TITLE
ポート番号修正

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,17 +10,6 @@ services:
     volumes:
       - transcendence-db-data:/var/lib/postgresql/data
 
-  pgadmin:
-    image: dpage/pgadmin4
-    ports:
-      - "4210:80"
-    depends_on:
-      - db
-    env_file:
-      - .env
-    volumes:
-      - transcendence-pgadmin-data:/var/lib/pgadmin
-
   minio:
     image: minio/minio:RELEASE.2021-06-17T00-10-46Z
     ports:
@@ -70,11 +59,22 @@ services:
   swagger-ui:
     image: swaggerapi/swagger-ui
     ports:
-      - "4213:8080"
+      - "8080:8080"
     volumes:
       - "./docs/openapi.yaml:/openapi.yaml"
     environment:
       SWAGGER_JSON: /openapi.yaml
+
+  pgadmin:
+    image: dpage/pgadmin4
+    ports:
+      - "8081:80"
+    depends_on:
+      - db
+    env_file:
+      - .env
+    volumes:
+      - transcendence-pgadmin-data:/var/lib/pgadmin
 
 volumes:
   transcendence-db-data:


### PR DESCRIPTION
## チケットへのリンク
なし
## やったこと
swaggerとpgadminのユーティリティ系のコンテナのポートを変更しました。
サービス本体のポートを42xxに統一するようにしたいと思います。
## やらないこと

## テスト
`docker compose up -d`で立ち上げた後、transcendence本体とswaggerやpgadminが正しく動作することを確認してください。
## その他
